### PR TITLE
Add function arguments

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -154,9 +154,7 @@ disable=raw-checker-failed,
         use-symbolic-message-instead,
 	missing-function-docstring,
 	missing-class-docstring,
-	missing-module-docstring,
-      too-many-arguments,
-      too-many-locals
+	missing-module-docstring
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option
@@ -438,7 +436,7 @@ exclude-too-few-public-methods=
 ignored-parents=
 
 # Maximum number of arguments for function / method.
-max-args=5
+max-args=9
 
 # Maximum number of attributes for a class (see R0902).
 max-attributes=7
@@ -450,7 +448,7 @@ max-bool-expr=5
 max-branches=12
 
 # Maximum number of locals for function / method body.
-max-locals=15
+max-locals=18
 
 # Maximum number of parents for a class (see R0901).
 max-parents=7

--- a/pylintrc
+++ b/pylintrc
@@ -152,9 +152,10 @@ disable=raw-checker-failed,
         useless-suppression,
         deprecated-pragma,
         use-symbolic-message-instead,
-	missing-function-docstring,
-	missing-class-docstring,
-	missing-module-docstring
+        missing-function-docstring,
+        missing-class-docstring,
+        missing-module-docstring,
+        too-many-positional-arguments
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option
@@ -437,9 +438,6 @@ ignored-parents=
 
 # Maximum number of arguments for function / method.
 max-args=9
-
-# Maximum number of positional arguments for function / method.
-max-positional-args=9
 
 # Maximum number of attributes for a class (see R0902).
 max-attributes=7

--- a/pylintrc
+++ b/pylintrc
@@ -154,7 +154,9 @@ disable=raw-checker-failed,
         use-symbolic-message-instead,
 	missing-function-docstring,
 	missing-class-docstring,
-	missing-module-docstring
+	missing-module-docstring,
+      too-many-arguments,
+      too-many-locals
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/pylintrc
+++ b/pylintrc
@@ -438,6 +438,9 @@ ignored-parents=
 # Maximum number of arguments for function / method.
 max-args=9
 
+# Maximum number of positional arguments for function / method.
+max-positional-args=9
+
 # Maximum number of attributes for a class (see R0902).
 max-attributes=7
 

--- a/sa818.py
+++ b/sa818.py
@@ -122,7 +122,7 @@ class SA818:
     logger.info('Firmware %s, version: %s', version[1], '_'.join(version[2:]))
     return version
 
-  def set_radio(self, frequency, offset, bw, squelch, ctcss, dcs, tail):  #pylint: disable=too-many-arguments
+  def set_radio(self, frequency, offset, bw, squelch, ctcss, dcs, tail):
     tone = ctcss if ctcss else dcs
     if tone:                # 0000 = No ctcss or dcs tone
       tx_tone, rx_tone = tone

--- a/sa818.py
+++ b/sa818.py
@@ -122,7 +122,7 @@ class SA818:
     logger.info('Firmware %s, version: %s', version[1], '_'.join(version[2:]))
     return version
 
-  def set_radio(self, frequency, offset, bw, squelch, ctcss, dcs, tail):
+  def set_radio(self, frequency, offset, bw, squelch, ctcss, dcs, tail):  #pylint: disable=too-many-arguments
     tone = ctcss if ctcss else dcs
     if tone:                # 0000 = No ctcss or dcs tone
       tx_tone, rx_tone = tone

--- a/sa818.py
+++ b/sa818.py
@@ -122,51 +122,48 @@ class SA818:
     logger.info('Firmware %s, version: %s', version[1], '_'.join(version[2:]))
     return version
 
-  def set_radio(self, opts):
-    tone = opts.ctcss if opts.ctcss else opts.dcs
+  def set_radio(self, frequency, offset, bw, squelch, ctcss, dcs, tail):
+    tone = ctcss if ctcss else dcs
     if tone:                # 0000 = No ctcss or dcs tone
       tx_tone, rx_tone = tone
     else:
       tx_tone, rx_tone = ['0000', '0000']
 
-    if opts.offset == 0.0:
-      tx_freq = rx_freq = f"{opts.frequency:.4f}"
+    if offset == 0.0:
+      tx_freq = rx_freq = f"{frequency:.4f}"
     else:
-      rx_freq = f"{opts.frequency:.4f}"
-      tx_freq = f"{opts.frequency + opts.offset:.4f}"
+      rx_freq = f"{frequency:.4f}"
+      tx_freq = f"{frequency + offset:.4f}"
 
-    cmd = f"{self.SETGRP}={opts.bw},{tx_freq},{rx_freq},{tx_tone},{opts.squelch},{rx_tone}"
+    cmd = f"{self.SETGRP}={bw},{tx_freq},{rx_freq},{tx_tone},{squelch},{rx_tone}"
     self.send(cmd)
     time.sleep(1)
     response = self.readline()
     if response != '+DMOSETGROUP:0':
       logger.error('SA818 programming error')
     else:
-      bw_label = ['Narrow', 'Wide'][opts.bw]
-      if opts.ctcss:
+      bw_label = ['Narrow', 'Wide'][bw]
+      if ctcss:
         msg = "%s, BW: %s, Frequency (RX: %s / TX: %s), CTCSS (TX: %s / RX: %s), squelch: %s, OK"
         logger.info(msg, response, bw_label, rx_freq, tx_freq,
-                    CTCSS[int(tx_tone)], CTCSS[int(rx_tone)], opts.squelch)
-      elif opts.dcs:
+                    CTCSS[int(tx_tone)], CTCSS[int(rx_tone)], squelch)
+      elif dcs:
         msg = "%s, BW: %s Frequency (RX: %s / TX: %s), DCD (TX: %s / RX: %s), squelch: %s, OK"
         logger.info(msg, response, bw_label, rx_freq, tx_freq,
-                    tx_tone, rx_tone, opts.squelch)
+                    tx_tone, rx_tone, squelch)
       else:
         msg = "%s, BW: %s, RX frequency: %s, TX frequency: %s, squelch: %s, OK"
-        logger.info(msg, response, bw_label, rx_freq, tx_freq, opts.squelch)
+        logger.info(msg, response, bw_label, rx_freq, tx_freq, squelch)
 
-    if opts.tail is not None and opts.ctcss is not None:
-      self.tail(opts)
-    elif opts.tail is not None:
+    if tail is not None and ctcss is not None:
+      self.tail(tail)
+    elif tail is not None:
       logger.warning('Ignoring "--tail" specified without ctcss')
 
-  def set_filter(self, opts):
-    for key in ("emphasis", "highpass", "lowpass"):
-      if getattr(opts, key) is None:
-        setattr(opts, key, 1)
+  def set_filter(self, emphasis, highpass, lowpass):
     _rx = {0: 'enabled', 1: 'disabled'}
     # filters are pre-emphasis, high-pass, low-pass
-    cmd = f"{self.FILTER}={opts.emphasis},{opts.highpass},{opts.lowpass}"
+    cmd = f"{self.FILTER}={emphasis},{highpass},{lowpass}"
     self.send(cmd)
     time.sleep(1)
     response = self.readline()
@@ -174,28 +171,28 @@ class SA818:
       logger.error('SA818 set filter error')
     else:
       logger.info("%s filters [Pre/De]emphasis: %s, high-pass: %s, low-pass: %s",
-                  response, _rx[opts.emphasis], _rx[opts.highpass], _rx[opts.lowpass])
+                  response, _rx[emphasis], _rx[highpass], _rx[lowpass])
 
-  def set_volume(self, opts):
-    cmd = f"{self.VOLUME}={opts.level:d}"
+  def set_volume(self, level):
+    cmd = f"{self.VOLUME}={level:d}"
     self.send(cmd)
     time.sleep(1)
     response = self.readline()
     if response != "+DMOSETVOLUME:0":
       logger.error('SA818 set volume error')
     else:
-      logger.info("%s Volume level: %d, OK", response, opts.level)
+      logger.info("%s Volume level: %d, OK", response, level)
 
-  def tail(self, opts):
+  def tail(self, tail):
     _oc = {True: "open", False: "close"}
-    cmd = f"{self.TAIL}={int(opts.tail)}"
+    cmd = f"{self.TAIL}={int(tail)}"
     self.send(cmd)
     time.sleep(1)
     response = self.readline()
     if response != "+DMOSETTAIL:0":
       logger.error('SA818 set filter error')
     else:
-      logger.info("%s tail: %s", response, _oc[opts.tail])
+      logger.info("%s tail: %s", response, _oc[tail])
 
 
 def type_frequency(parg):
@@ -410,7 +407,7 @@ def main():
   if opts.func == 'version':
     radio.version()
   elif opts.func == 'radio':
-    radio.set_radio(opts)
+    radio.set_radio(opts.frequency, opts.offset, opts.bw, opts.squelch, opts.ctcss, opts.dcs, opts.tail)
   elif opts.func == 'filters':
     for key in ('emphasis', 'highpass', 'lowpass'):
       if getattr(opts, key) is not None:
@@ -418,9 +415,9 @@ def main():
     else:
       logger.error('filters need at least one argument')
       raise SystemExit('Argument error') from None
-    radio.set_filter(opts)
+    radio.set_filter(opts.emphasis, opts.highpass, opts.lowpass)
   elif opts.func == 'volume':
-    radio.set_volume(opts)
+    radio.set_volume(opts.level)
 
 
 if __name__ == "__main__":

--- a/sa818.py
+++ b/sa818.py
@@ -407,7 +407,15 @@ def main():
   if opts.func == 'version':
     radio.version()
   elif opts.func == 'radio':
-    radio.set_radio(opts.frequency, opts.offset, opts.bw, opts.squelch, opts.ctcss, opts.dcs, opts.tail)
+    radio.set_radio(
+      opts.frequency,
+      opts.offset,
+      opts.bw,
+      opts.squelch,
+      opts.ctcss,
+      opts.dcs,
+      opts.tail
+    )
   elif opts.func == 'filters':
     for key in ('emphasis', 'highpass', 'lowpass'):
       if getattr(opts, key) is not None:


### PR DESCRIPTION
I would like to use your code as a library within a project, but the interface was for me to open. So I added the arguments for the class functions and moved the argparse object in the caller function.
Like this it is now possible to use the class in another project and it is very easy to read the function definition with the required arguments.

I am sorry for all the "fix pylint" commits, looks like I have an older version which does not recognise the `too-many-positional-arguments` warnings.

I would like to add some type-hints as well, is this something you could use?