### PR TITLE
Add support for CTCSS or DCS on transmit or receive ONLY

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ SA818: INFO: +DMOSETVOLUME:0 Volume level: 5
 
 It is possible to specify a different CTCSS or DCS code for transmit and receive by separating the two codes by a comma (no spaces). For example, `--ctcss 100,88.5` will set the CTCSS 100Hz for transmit and 88.5Hz for receive.
 
+> [!NOTE]
+> It is also possible to specify CTCSS or DCS on transmit or receive only. For example, `--ctcss 100,None` will set the CTCSS 100Hz for transmit only (nothing for receive).
+
 ## Usage
 
 This program has for sections:

--- a/sa818.py
+++ b/sa818.py
@@ -149,9 +149,11 @@ class SA818:
         logger.info(msg, response, bw_label, rx_freq, tx_freq,
                     CTCSS[int(tx_tone)], CTCSS[int(rx_tone)], squelch)
       elif dcs:
-        msg = "%s, BW: %s Frequency (RX: %s / TX: %s), DCD (TX: %s / RX: %s), squelch: %s, OK"
+        tx_tone_display = None if tx_tone == '0000' else tx_tone
+        rx_tone_display = None if rx_tone == '0000' else rx_tone
+        msg = "%s, BW: %s Frequency (RX: %s / TX: %s), DCS (TX: %s / RX: %s), squelch: %s, OK"
         logger.info(msg, response, bw_label, rx_freq, tx_freq,
-                    tx_tone, rx_tone, squelch)
+                    tx_tone_display, rx_tone_display, squelch)
       else:
         msg = "%s, BW: %s, RX frequency: %s, TX frequency: %s, squelch: %s, OK"
         logger.info(msg, response, bw_label, rx_freq, tx_freq, squelch)

--- a/sa818.py
+++ b/sa818.py
@@ -32,6 +32,7 @@ CTCSS = (
 )
 
 DCS_CODES = [
+  "None",
   "023", "025", "026", "031", "032", "036", "043", "047", "051", "053", "054",
   "065", "071", "072", "073", "074", "114", "115", "116", "125", "131", "132",
   "134", "143", "152", "155", "156", "162", "165", "172", "174", "205", "223",
@@ -218,15 +219,18 @@ def type_ctcss(parg):
     raise argparse.ArgumentError from None
 
   for code in codes:
-    try:
-      ctcss = str(float(code))
-      if ctcss not in CTCSS:
-        raise ValueError
-      ctcss = CTCSS.index(ctcss)
-      tone_codes.append(f"{ctcss:04d}")
-    except ValueError:
-      logger.error(err_msg)
-      raise argparse.ArgumentTypeError from None
+    if code.lower() == "none":
+      tone_codes.append("0000")  # No CTCSS
+    else:
+      try:
+        ctcss = str(float(code))
+        if ctcss not in CTCSS:
+          raise ValueError
+        ctcss = CTCSS.index(ctcss)
+        tone_codes.append(f"{ctcss:04d}")
+      except ValueError:
+        logger.error(err_msg)
+        raise argparse.ArgumentTypeError from None
 
   return tone_codes
 
@@ -242,19 +246,22 @@ def type_dcs(parg):
     raise argparse.ArgumentError from None
 
   for code in codes:
-    if code[-1] not in ('N', 'I'):
-      logger.error(err_msg)
-      raise argparse.ArgumentError from None
-
-    code, direction = code[:-1], code[-1]
-    try:
-      dcs = f"{int(code):03d}"
-      if dcs not in DCS_CODES:
+    if code.lower() == "none":
+      dcs_codes.append("0000")  # No DCS
+    else:
+      if code[-1] not in ('N', 'I'):
         logger.error(err_msg)
-        raise argparse.ArgumentError
-    except ValueError:
-      raise argparse.ArgumentTypeError from None
-    dcs_codes.append(dcs + direction)
+        raise argparse.ArgumentError from None
+
+      code, direction = code[:-1], code[-1]
+      try:
+        dcs = f"{int(code):03d}"
+        if dcs not in DCS_CODES:
+          logger.error(err_msg)
+          raise argparse.ArgumentError
+      except ValueError:
+        raise argparse.ArgumentTypeError from None
+      dcs_codes.append(dcs + direction)
 
   return dcs_codes
 


### PR DESCRIPTION
Hello,

I've simply added support for CTCSS or DCS on transmit or receive ONLY.

For example, it's now possible to do this:

```
root@f4hwn:~/SA818# python3 sa818.py --port /dev/ttyS2 radio --frequency 434.975 --ctcss 100,None
SA818: INFO: +DMOSETGROUP:0, BW: Wide, Frequency (RX: 434.9750 / TX: 434.9750), CTCSS (TX: 100.0 / RX: None), squelch: 4, OK

```

```
root@f4hwn:~/SA818# python3 sa818.py --port /dev/ttyS2 radio --frequency 434.975 --dcs None,051N
SA818: INFO: +DMOSETGROUP:0, BW: Wide Frequency (RX: 434.9750 / TX: 434.9750), DCS (TX: None / RX: 051N), squelch: 4, OK
```

Thank you for your good job on this project.

Armel F4HWN.